### PR TITLE
Switch scans from OLS to archive.org

### DIFF
--- a/se-lint-ignore.xml
+++ b/se-lint-ignore.xml
@@ -1,11 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <se-lint-ignore>
-	<file path="colophon.xhtml">
-		<ignore>
-			<code>m-007</code>
-			<reason>IA links point to page where the stories start.</reason>
-		</ignore>
-	</file>
 	<file path="content.opf">
 		<ignore>
 			<code>m-007</code>

--- a/src/epub/content.opf
+++ b/src/epub/content.opf
@@ -119,66 +119,90 @@
 			&lt;p&gt;This collection gathers stories that were published in &lt;i&gt;Analog&lt;/i&gt;, &lt;i&gt;Astounding Science Fiction&lt;/i&gt;, &lt;i&gt;Amazing Stories&lt;/i&gt; and others. Ordered by date of first publication, they range from spy adventures to the ultimate expression of corporate warfare and from a very short 1000-word story to full-blown novellas.&lt;/p&gt;
 		</meta>
 		<dc:language>en-US</dc:language>
-		<dc:source>https://www.gutenberg.org/ebooks/29940</dc:source>
-		<dc:source>https://www.gutenberg.org/ebooks/40954</dc:source>
-		<dc:source>https://www.gutenberg.org/ebooks/30035</dc:source>
-		<dc:source>https://www.gutenberg.org/ebooks/29206</dc:source>
-		<dc:source>https://www.gutenberg.org/ebooks/23942</dc:source>
-		<dc:source>https://www.gutenberg.org/ebooks/23929</dc:source>
-		<dc:source>https://www.gutenberg.org/ebooks/24749</dc:source>
-		<dc:source>https://www.gutenberg.org/ebooks/30712</dc:source>
-		<dc:source>https://www.gutenberg.org/ebooks/23669</dc:source>
-		<dc:source>https://www.gutenberg.org/ebooks/27393</dc:source>
-		<dc:source>https://www.gutenberg.org/ebooks/26741</dc:source>
-		<dc:source>https://www.gutenberg.org/ebooks/24247</dc:source>
-		<dc:source>https://www.gutenberg.org/ebooks/30338</dc:source>
-		<dc:source>https://www.gutenberg.org/ebooks/30334</dc:source>
-		<dc:source>https://www.gutenberg.org/ebooks/51799</dc:source>
-		<dc:source>https://www.gutenberg.org/ebooks/30339</dc:source>
-		<dc:source>https://www.gutenberg.org/ebooks/24370</dc:source>
-		<dc:source>https://www.gutenberg.org/ebooks/23197</dc:source>
-		<dc:source>https://www.gutenberg.org/ebooks/23194</dc:source>
-		<dc:source>https://www.gutenberg.org/ebooks/31008</dc:source>
-		<dc:source>https://www.gutenberg.org/ebooks/52995</dc:source>
-		<dc:source>https://www.gutenberg.org/ebooks/59514</dc:source>
-		<dc:source>https://www.gutenberg.org/ebooks/60761</dc:source>
-		<dc:source>https://www.gutenberg.org/ebooks/63963</dc:source>
-		<dc:source>https://www.gutenberg.org/ebooks/63989</dc:source>
-		<dc:source>https://www.gutenberg.org/ebooks/63741</dc:source>
+		<!-- Tourists to Terra -->
 		<dc:source>https://www.gutenberg.org/ebooks/65077</dc:source>
-		<dc:source>https://www.gutenberg.org/ebooks/65140</dc:source>
-		<dc:source>https://www.gutenberg.org/ebooks/65221</dc:source>
-		<dc:source>https://www.gutenberg.org/ebooks/65938</dc:source>
-		<dc:source>https://www.pgdp.org/ols/tools/biblio.php?id=projectID4aa2556c5cbaf</dc:source>
-		<dc:source>https://www.pgdp.org/ols/tools/biblio.php?id=projectID505a4e8aaf930</dc:source>
-		<dc:source>https://archive.org/details/1954-01_IF/page/n115</dc:source>
-		<dc:source>https://www.pgdp.org/ols/tools/biblio.php?id=projectID49c82d6189993</dc:source>
-		<dc:source>https://www.pgdp.org/ols/tools/biblio.php?id=projectID46917350e5c63</dc:source>
-		<dc:source>https://www.pgdp.org/ols/tools/biblio.php?id=projectID469171f14fd3f</dc:source>
-		<dc:source>https://www.pgdp.org/ols/tools/biblio.php?id=projectID46916599916da</dc:source>
-		<dc:source>https://www.pgdp.org/ols/tools/biblio.php?id=projectID4914cf86f4221</dc:source>
-		<dc:source>https://www.pgdp.org/ols/tools/biblio.php?id=projectID4682eef623947</dc:source>
-		<dc:source>https://archive.org/details/Amazing_Stories_v34n11_1960-11_UnkSc-cape1736/page/n71</dc:source>
-		<dc:source>https://www.pgdp.org/ols/tools/biblio.php?id=projectID48c445cc111b3</dc:source>
-		<dc:source>https://www.pgdp.org/ols/tools/biblio.php?id=projectID46d4c9827eadb</dc:source>
-		<dc:source>https://www.pgdp.org/ols/tools/biblio.php?id=projectID4914d22f3bd3e</dc:source>
-		<dc:source>https://www.pgdp.org/ols/tools/biblio.php?id=projectID4914ddd4f0ab1</dc:source>
-		<dc:source>https://archive.org/details/Galaxy_v19n05_1961-06_modified/page/n3</dc:source>
-		<dc:source>https://www.pgdp.org/ols/tools/biblio.php?id=projectID4914e24d73ccb</dc:source>
-		<dc:source>https://www.pgdp.org/ols/tools/biblio.php?id=projectID46e33170e5708</dc:source>
-		<dc:source>https://www.pgdp.org/ols/tools/biblio.php?id=projectID4671dcb9cec18</dc:source>
-		<dc:source>https://www.pgdp.org/ols/tools/biblio.php?id=projectID4671d4f5aee30</dc:source>
-		<dc:source>https://www.pgdp.org/ols/tools/biblio.php?id=projectID49443df3561e2</dc:source>
-		<dc:source>https://www.pgdp.org/ols/tools/biblio.php?id=projectID57cb212a1c5ba</dc:source>
-		<dc:source>https://archive.org/details/1956-06_IF_modified/page/n47/</dc:source>
-		<dc:source>https://archive.org/details/1960-01_IF/page/n3/</dc:source>
-		<dc:source>https://archive.org/details/Planet_Stories_v05n01_1951-07_oak/page/n67/</dc:source>
-		<dc:source>https://archive.org/details/Planet_Stories_v05n03_1951-11/page/n33/</dc:source>
-		<dc:source>https://archive.org/details/Planet_Stories_v06n05_1954-03/page/n59/</dc:source>
 		<dc:source>https://archive.org/details/Imagination_v01n02_1950-12_LennyS-cape1736/page/n35/mode/2up</dc:source>
+		<!-- Not in the Rules -->
+		<dc:source>https://www.gutenberg.org/ebooks/65140</dc:source>
 		<dc:source>https://archive.org/details/Imagination_v02n02_1951-04.Grenleafcape1736/page/n133/mode/2up</dc:source>
+		<!-- The Martians and the Coys -->
+		<dc:source>https://www.gutenberg.org/ebooks/65221</dc:source>
 		<dc:source>https://archive.org/details/Imagination_v02n03_1951-06_LennyS-cape1736/page/n77/mode/2up</dc:source>
+		<!-- Mercy Flight -->
+		<dc:source>https://www.gutenberg.org/ebooks/63963</dc:source>
+		<dc:source>https://archive.org/details/Planet_Stories_v05n01_1951-07_oak/page/n67/</dc:source>
+		<!-- Halftripper -->
+		<dc:source>https://www.gutenberg.org/ebooks/63989</dc:source>
+		<dc:source>https://archive.org/details/Planet_Stories_v05n03_1951-11/page/n33/</dc:source>
+		<!-- The Cosmic Bluff -->
+		<dc:source>https://www.gutenberg.org/ebooks/65938</dc:source>
 		<dc:source>https://archive.org/details/Imagination_v03n06_1952-10_LennyS-cape1736/page/n125/mode/2up</dc:source>
+		<!-- Dogfight—1973 -->
+		<dc:source>https://www.gutenberg.org/ebooks/29940</dc:source>
+		<dc:source>https://archive.org/details/Imagination_v04n06_1953-07_cape1736</dc:source>
+		<!-- Potential Enemy -->
+		<dc:source>https://www.gutenberg.org/ebooks/40954</dc:source>
+		<!-- Off Course -->
+		<dc:source>https://www.gutenberg.org/ebooks/30035</dc:source>
+		<dc:source>https://archive.org/details/1954-01_IF/page/n115</dc:source>
+		<!-- The Galactic Ghost -->
+		<dc:source>https://www.gutenberg.org/ebooks/63741</dc:source>
+		<dc:source>https://archive.org/details/Planet_Stories_v06n05_1954-03/page/n59/</dc:source>
+		<!-- Happy Ending -->
+		<dc:source>https://www.gutenberg.org/ebooks/29206</dc:source>
+		<dc:source>https://archive.org/details/Fantastic_Universe_v08n03_Sep_1957_Wilddog-DCP</dc:source>
+		<!-- After Some Tomorrow -->
+		<dc:source>https://www.gutenberg.org/ebooks/59514</dc:source>
+		<dc:source>https://archive.org/details/1956-06_IF_modified/page/n47/</dc:source>
+		<!-- Unborn Tomorrow -->
+		<dc:source>https://www.gutenberg.org/ebooks/23942</dc:source>
+		<dc:source>https://archive.org/details/Astounding_v63n04_1959-06_EXciter-LennyS</dc:source>
+		<!-- The Good Seed -->
+		<dc:source>https://www.gutenberg.org/ebooks/60761</dc:source>
+		<dc:source>https://archive.org/details/1960-01_IF/page/n3/</dc:source>
+		<!-- Summit -->
+		<dc:source>https://www.gutenberg.org/ebooks/23669</dc:source>
+		<dc:source>https://archive.org/details/sim_analog-science-fiction-fact_1960-02_64_6</dc:source>
+		<!-- Revolution -->
+		<dc:source>https://www.gutenberg.org/ebooks/23929</dc:source>
+		<dc:source>https://archive.org/details/sim_analog-science-fiction-fact_1960-05_65_3</dc:source>
+		<!-- Adaptation -->
+		<dc:source>https://www.gutenberg.org/ebooks/24749</dc:source>
+		<dc:source>https://archive.org/details/sim_analog-science-fiction-fact_1960-08_65_6</dc:source>
+		<!-- Combat -->
+		<dc:source>https://www.gutenberg.org/ebooks/30712</dc:source>
+		<dc:source>https://archive.org/details/sim_analog-science-fiction-fact_1960-10_66_2</dc:source>
+		<!-- Medal of Honor -->
+		<dc:source>https://www.gutenberg.org/ebooks/27393</dc:source>
+		<dc:source>https://archive.org/details/Amazing_Stories_v34n11_1960-11_UnkSc-cape1736</dc:source>
+		<!-- I'm a Stranger Here Myself (Amazing Stories 12/1960) -->
+		<dc:source>https://www.gutenberg.org/ebooks/26741</dc:source>
+		<!-- Gun For Hire -->
+		<dc:source>https://www.gutenberg.org/ebooks/24247</dc:source>
+		<dc:source>https://archive.org/details/sim_analog-science-fiction-fact_1960-12_66_4</dc:source>
+		<!-- Freedom -->
+		<dc:source>https://www.gutenberg.org/ebooks/30338</dc:source>
+		<dc:source>https://archive.org/details/sim_analog-science-fiction-fact_1961-06_17_6</dc:source>
+		<!-- Ultima Thule -->
+		<dc:source>https://www.gutenberg.org/ebooks/30334</dc:source>
+		<dc:source>https://archive.org/details/sim_analog-science-fiction-fact_1961-03_67_1</dc:source>
+		<!-- Farmer -->
+		<dc:source>https://www.gutenberg.org/ebooks/51799</dc:source>
+		<dc:source>https://archive.org/details/Galaxy_v19n05_1961-06_modified/page/n3</dc:source>
+		<!-- Status Quo -->
+		<dc:source>https://www.gutenberg.org/ebooks/30339</dc:source>
+		<dc:source>https://archive.org/details/sim_analog-science-fiction-fact_1961-08_67_6</dc:source>
+		<!-- Mercenary (Analog 4/1962) -->
+		<dc:source>https://www.gutenberg.org/ebooks/24370</dc:source>
+		<!-- Subversive (Analog 12/1962)-->
+		<dc:source>https://www.gutenberg.org/ebooks/23197</dc:source>
+		<!-- The Common Man (Analog 01/1963) -->
+		<dc:source>https://www.gutenberg.org/ebooks/23194</dc:source>
+		<!-- Frigid Fracas (Analog 3-4/1963)-->
+		<dc:source>https://www.gutenberg.org/ebooks/31008</dc:source>
+		<!-- Spaceman on a Spree -->
+		<dc:source>https://www.gutenberg.org/ebooks/52995</dc:source>
+		<dc:source>https://archive.org/details/Worlds_of_Tomorrow_v01n02_1963-06_LennyS-Exciter</dc:source>
 		<meta property="se:production-notes">All stories by Mack Reynolds except Happy Ending which was written by Mack Reynolds and Frederic Brown.</meta>
 		<meta property="se:word-count">295372</meta>
 		<meta property="se:reading-ease.flesch">76.22</meta>

--- a/src/epub/text/colophon.xhtml
+++ b/src/epub/text/colophon.xhtml
@@ -23,10 +23,8 @@
 			for<br/>
 			<a href="https://www.gutenberg.org/ebooks/author/25744">Project Gutenberg</a><br/>
 			and on digital scans available at the<br/>
-			<a href="https://www.pgdp.org/ols/index.php">Distributed Proofreaders Open Library System</a><br/>
-			and the<br/>
-			<a href="https://archive.org">Internet Archive</a> (“<a href="https://archive.org/details/Planet_Stories_v05n01_1951-07_oak">Mercy Flight</a>,” “<a href="https://archive.org/details/Planet_Stories_v05n03_1951-11/">Halftripper</a>,” “<a href="https://archive.org/details/Planet_Stories_v06n05_1954-03">The Galactic Ghost</a>,” “<a href="https://archive.org/details/1954-01_IF/page/n115">Off Course</a>,” “<a href="https://archive.org/details/1954-01_IF/page/n115">Medal of Honor</a>,” “<a href="https://archive.org/details/1954-01_IF/page/n115">Farmer</a>,” “<a href="https://archive.org/details/1956-06_IF_modified/page/n47">After Some Tomorrow</a>,” and “<a href="https://archive.org/details/1960-01_IF/page/n3">The Good Seed</a>”).</p>
-			<p>The cover page is adapted from<br/>
+			<a href="https://archive.org/details/Imagination_v01n02_1950-12_LennyS-cape1736/">Internet Archive</a>.</p>
+ 			<p>The cover page is adapted from<br/>
 			<i epub:type="se:name.visual-art.painting">Artillery</i>,<br/>
 			a painting completed in 1911 by<br/>
 			<a href="https://en.wikipedia.org/wiki/Roger_de_La_Fresnaye">Roger de la Fresnaye</a>.<br/>

--- a/src/epub/text/imprint.xhtml
+++ b/src/epub/text/imprint.xhtml
@@ -13,7 +13,8 @@
 			</header>
 			<p>This ebook is the product of many hours of hard work by volunteers for <a href="https://standardebooks.org">Standard Ebooks</a>, and builds on the hard work of other literature lovers made possible by the public domain.</p>
 			<p>This particular ebook is based on transcriptions produced for <a href="https://www.gutenberg.org/ebooks/author/25744">Project Gutenberg</a><br/>
-			and on digital scans available at the <a href="https://www.pgdp.org/ols/index.php">Distributed Proofreaders Open Library System</a>.</p>
+			and on digital scans available at the<br/>
+			<a href="https://archive.org/details/Imagination_v01n02_1950-12_LennyS-cape1736/">Internet Archive</a>.</p>
 			<p>The writing and artwork within are believed to be in the <abbr>U.S.</abbr> public domain, and Standard Ebooks releases this ebook edition under the terms in the <a href="https://creativecommons.org/publicdomain/zero/1.0/">CC0 1.0 Universal Public Domain Dedication</a>. For full license information, see the <a href="uncopyright.xhtml">Uncopyright</a> at the end of this ebook.</p>
 			<p>Standard Ebooks is a volunteer-driven project that produces ebook editions of public domain literature using modern typography, technology, and editorial standards, and distributes them free of cost. You can download this and other ebooks carefully produced for true book lovers at <a href="https://standardebooks.org">standardebooks.org</a>.</p>
 		</section>


### PR DESCRIPTION
Bruce did all the work on this one; it includes the scans he could find, there are a half-dozen or so he couldn't. (I did some searching and couldn't, either.)

The existing archive scans had page numbers on them; I left them alone. I organized the transcriptions and scans by story, put them in spine order, and added a comment so we know what goes with what story. This matches what we have for Leiber, e.g., and others.